### PR TITLE
Remove live.com in whitelist

### DIFF
--- a/white.list
+++ b/white.list
@@ -6103,7 +6103,6 @@ liuxue3600.com
 liuxue51.net
 liuxue86.com
 liuxueca.com
-live.com
 live754.com
 live800.com
 liveuc.net


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Remove 'live.com' in whitelist
-
-

@txthinking 
